### PR TITLE
Permit install of DKMS packages with lustre_dkms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This role installs and configures Lustre clients.
 Role Variables
 --------------
 
-TBC
+By default, the role will install the Lustre modules built for the running
+kernel. (`lustre-client-modules-{{ ansible_facts['kernel'] }}`). If one needs
+to install DKMS packages instead, define `lustre_dkms: true`.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 lustre_configure_repos: false
 lustre_upgrade: false
+# Install the DKMS package
+lustre_dkms: false
 
 lustre_lnet_networks: "o2ib0(ib0)"
 # Do not restart lnet service by default

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -2,6 +2,6 @@
 - name: Install Lustre packages for Debian OS family
   ansible.builtin.package:
     name:
-      - "lustre-client-modules-{{ ansible_facts['kernel'] }}"
+      - "lustre-client-modules-{{ lustre_dkms | bool | ternary('dkms', ansible_facts['kernel']) }}"
       - lustre-client-utils
     state: "{{ 'latest' if lustre_upgrade else 'present' }}"


### PR DESCRIPTION
Add a new variable `lustre_dkms` to toggle the installation of the DKMS packages. Default to False.