### PR TITLE
Update APT repository when lustre_upgrade is true

### DIFF
--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: Update APT repository
+  when: lustre_upgrade
+  ansible.builtin.apt:
+    update_cache: true
+
 - name: Install Lustre packages for Debian OS family
   ansible.builtin.package:
     name:


### PR DESCRIPTION
If one explicitely requires to upgrade Lustre, make sure to update the APT repository first.