### PR TITLE
feat: Add support for DKMS patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-Lustre
-======
+# Lustre
 
 This role installs and configures Lustre clients for high-performance computing
 environments.
 
-Role Variables
---------------
+## Role Variables
 
-Required variables:
+### Required Variables
+
 - `lustre_filesystems`: List of Lustre filesystems to mount
   ```yaml
   lustre_filesystems:
@@ -19,35 +18,47 @@ Required variables:
       state: mounted              # Optional: Mount state (default: mounted)
   ```
 
-Optional variables:
-- `lustre_configure_repos`: Configure package repositories (default: false)
-- `lustre_apt_priority`: APT repository priority
-- `lustre_apt_repository`: APT repository URL for Lustre packages. The URL determines
-  which version will be installed:
+### Optional Variables
 
-  ```yaml
-  # Latest stable release
-  lustre_apt_repository: 'deb https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2204/client/ ./'
-
-  # Specific version (example)
-  lustre_apt_repository: 'deb https://downloads.whamcloud.com/public/lustre/lustre-2.15.1/ubuntu2204/client/ ./'
-  ```
-  Note: The repository URL must match your Ubuntu version (e.g. ubuntu2204)
-
+#### Repository Configuration
+- `lustre_configure_repos`: Configure Lustre repositories (default: false)
+  - When true, requires `lustre_apt_repository` to be set
+- `lustre_apt_repository`: APT repository URL for Lustre packages
+  - Example: 'deb https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2204/client/ ./'
 - `lustre_gpg_key`: URL of the GPG key for the Lustre repository
+
+#### Installation Configuration
+- `lustre_upgrade`: Upgrade Lustre packages to latest version (default: false)
+
+#### DKMS Configuration
 - `lustre_dkms`: Use DKMS packages instead of pre-built modules (default: false)
   - When false (default): Installs pre-built modules for the running kernel
     (`lustre-client-modules-{{ ansible_facts['kernel'] }}`)
   - When true: Installs DKMS packages to build modules for installed kernels
+- `lustre_dkms_patches`: List of patches to apply to DKMS modules
+  ```yaml
+  lustre_dkms_patches:
+    - src: patches/0001-fix.patch
+      version: "2.15.6"
+      order: 0
+    - src: patches/0002-fix.patch
+      version: "2.15.6"
+      order: 1
+  ```
+  Each patch must have:
+  - `src`: Path to the patch file
+  - `version`: Lustre version to apply the patch to
+  - `order`: Order in which to apply the patch (must be sequential starting from 0)
+
+#### LNet Configuration
 - `lustre_lnet_conf`: Custom LNet configuration (see defaults/main.yml for example)
 - `lustre_lnet_networks`: LNet network configuration (default: "o2ib0(ib0)")
 - `lustre_lnet_restart`: Restart LNet service after configuration (default: false)
-- `lustre_upgrade`: Upgrade Lustre packages to latest version (default: false)
 
-Example Playbook
-----------------
+## Example Playbooks
 
-Basic installation:
+### Basic Installation
+
 ```yaml
 - hosts: lustre_clients
   roles:
@@ -60,15 +71,22 @@ Basic installation:
             path: /mnt/lustre
 ```
 
-Advanced configuration with InfiniBand:
+### With DKMS Patches
+
 ```yaml
 - hosts: lustre_clients
   roles:
     - role: btravouillon.lustre
       vars:
         lustre_configure_repos: true
-        lustre_apt_repository: 'deb https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2204/client/ ./'
-        lustre_lnet_networks: "o2ib0(ib0)"
+        lustre_dkms: true
+        lustre_dkms_patches:
+          - src: patches/0001-fix.patch
+            version: "2.15.6"
+            order: 0
+          - src: patches/0002-fix.patch
+            version: "2.15.6"
+            order: 1
         lustre_filesystems:
           - src: lustre@o2ib0:/lustre
             path: /mnt/lustre
@@ -76,24 +94,39 @@ Advanced configuration with InfiniBand:
             boot: true
 ```
 
-Requirements
-------------
+## Requirements
 
 - Ansible 9 or higher
-- Supported OS: Debian-based systems
+- Debian-based system (Ubuntu, Debian)
 - Network connectivity to Lustre servers
 
-License
--------
+## Troubleshooting
+
+### DKMS Patches
+
+1. **Patch Application Fails**
+   - Verify patch file format is correct
+   - Check if patch version matches installed Lustre version
+   - Ensure patch order is sequential starting from 0
+
+2. **Module Build Fails**
+   - Check DKMS logs: `/var/lib/dkms/lustre-client-modules/<kernel-version>/log/make.log`
+   - Verify kernel headers are installed
+   - Check if patch conflicts with existing code
+
+3. **Module Not Loading**
+   - Check module status: `dkms status -m lustre-client-modules -v <version>`
+   - Verify module is built for current kernel
+   - Check system logs for errors
+
+## License
 
 MIT
 
-Author Information
-------------------
+## Author Information
 
 - Bruno Travouillon [@btravouillon](https://github.com/btravouillon)
 
-Support
--------
+## Support
 
 Report bugs and feature requests on [GitHub Issues](https://github.com/btravouillon/ansible-role-lustre/issues)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,9 +11,18 @@ lustre_configure_repos: false
 # Set to true to upgrade to latest version
 lustre_upgrade: false
 
+# DKMS Configuration
+# ------------------
 # Whether to use DKMS packages instead of pre-built modules
 # Set to true if you need to build modules for custom kernels
 lustre_dkms: false
+
+# List of patches to apply to DKMS source
+# Each patch should be a dictionary with:
+#   - src: Path to the patch file (relative to playbook)
+#   - version: Lustre version this patch applies to (e.g. "2.15.6")
+#   - order: Order in which the patch should be applied (0-based index)
+lustre_dkms_patches: []
 
 # LNet Configuration
 # -----------------

--- a/tasks/dkms-patches.yml
+++ b/tasks/dkms-patches.yml
@@ -1,0 +1,34 @@
+---
+- name: Validate patch entries
+  ansible.builtin.fail:
+    msg: "Each patch must have src, version, and order fields"
+  when: >
+    lustre_dkms_patches | selectattr('src', 'undefined') | list | length > 0 or
+    lustre_dkms_patches | selectattr('version', 'undefined') | list | length > 0 or
+    lustre_dkms_patches | selectattr('order', 'undefined') | list | length > 0
+
+- name: Ensure DKMS is installed
+  ansible.builtin.package:
+    name: dkms
+    state: present
+
+- name: Create patches directory
+  ansible.builtin.file:
+    path: "/usr/src/lustre-client-modules-{{ item }}/patches/"
+    state: directory
+    mode: '0755'
+  loop: "{{ lustre_dkms_patches | map(attribute='version') | unique | list }}"
+
+- name: Copy patch files
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "/usr/src/lustre-client-modules-{{ item.version }}/patches/"
+    mode: '0644'
+  loop: "{{ lustre_dkms_patches }}"
+
+- name: Generate DKMS config files
+  ansible.builtin.template:
+    src: dkms.conf.j2
+    dest: "/etc/dkms/lustre-client-modules-{{ item }}.conf"
+    mode: '0644'
+  loop: "{{ lustre_dkms_patches | map(attribute='version') | unique | list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,11 @@
     file: "repositories-{{ ansible_facts['os_family'] }}.yml"
   when: lustre_configure_repos
 
+- name: Apply DKMS patches
+  ansible.builtin.include_tasks:
+    file: dkms-patches.yml
+  when: lustre_dkms | bool and lustre_dkms_patches | length > 0
+
 - name: Install Lustre client
   ansible.builtin.include_tasks:
     file: "install-{{ ansible_facts['os_family'] }}.yml"

--- a/templates/dkms.conf.j2
+++ b/templates/dkms.conf.j2
@@ -1,0 +1,3 @@
+{% for patch in lustre_dkms_patches | selectattr('version', 'equalto', item) | sort(attribute='order') %}
+PATCH[{{ patch.order }}]={{ patch.src | basename }}
+{% endfor %} 


### PR DESCRIPTION
Add ability to apply custom patches to DKMS-built Lustre modules. This feature allows users to apply fixes or customizations to the Lustre client modules before building.

Key changes:
- Add lustre_dkms_patches variable for patch configuration
- Create dkms-patches.yml for patch handling tasks
- Add dkms.conf.j2 template for DKMS configuration
- Update documentation with examples and troubleshooting

The feature requires:
- lustre_dkms set to true
- Patches in git format
- Sequential patch ordering
- Version matching installed Lustre version