### PR TITLE
feat: Allow to define a custom lustre.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ environments.
 - `lustre_lnet_networks`: LNet network configuration (default: "o2ib0(ib0)")
 - `lustre_lnet_restart`: Restart LNet service after configuration (default: false)
 
+#### Lustre Configuration
+The role uses a basic template to configure `lustre.conf` by default.
+
+To override this template:
+- `lustre_conf`: Custom lustre.conf configuration (see defaults/main.yml for example)
+
 ## Example Playbooks
 
 ### Basic Installation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,13 @@ lustre_lnet_conf: |
                 fmr_cache: 1
             CPT: "[0,1]"
 
+# Lustre Configuration
+# --------------------
+# lustre_conf: |-
+#   options lnet network="{{ lustre_lnet_networks }}"
+#   options ko2iblnd credits=7424
+#   [...]
+
 # Filesystem Configuration
 # ----------------------
 # List of Lustre filesystems to mount

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,6 @@
     owner: root
     group: root
     mode: "0644"
-  when: lustre_lnet_networks is defined
   notify: "Restart LNet service"
 
 - name: Install /etc/lnet.conf

--- a/templates/lustre.conf.j2
+++ b/templates/lustre.conf.j2
@@ -1,5 +1,9 @@
 # {{ ansible_managed }}
+{% if lustre_conf is defined %}
+{{ lustre_conf }}
+{% else %}
 options lnet networks="{{ lustre_lnet_networks }}"
 options lnet lnet_transaction_timeout=100 lnet_retry_count=2
 options ko2iblnd peer_credits=32 peer_credits_hiw=16 concurrent_sends=64
 options libcfs cpu_pattern="" cpu_npartitions=4
+{% endif %}


### PR DESCRIPTION
The default template will not cover advanced configuration.

Remove the test to check if `lustre_lnet_networks` is defined since it is by default. Moreover, we want to manage the `lustre.conf` without this variable when using `lustre_conf`.