### PR TITLE
feat: Allow to install systemd drop-in for LNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ environments.
 - `lustre_lnet_conf`: Custom LNet configuration (see defaults/main.yml for example)
 - `lustre_lnet_networks`: LNet network configuration (default: "o2ib0(ib0)")
 - `lustre_lnet_restart`: Restart LNet service after configuration (default: false)
+- `lustre_lnet_systemd_override`: Configure a drop-in file for LNet service
 
 #### Lustre Configuration
 The role uses a basic template to configure `lustre.conf` by default.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,12 @@ lustre_lnet_conf: |
                 fmr_cache: 1
             CPT: "[0,1]"
 
+# Override for systemd lnet.service
+# lustre_lnet_systemd_override: |
+#   [Service]
+#   ExecStart=
+#   ExecStart=/sbin/modprobe lustre
+
 # Lustre Configuration
 # --------------------
 # lustre_conf: |-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,13 @@
   ansible.builtin.apt:
     update_cache: true
 
+- name: Run daemon-reload for LNet service
+  ansible.builtin.systemd_service:
+    name: lnet.service
+    daemon_reload: true
+
 - name: Restart LNet service
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: lnet.service
     state: restarted
-  when: lustre_lnet_restart
+  when: lustre_lnet_restart | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,40 @@
   when: lustre_lnet_conf is defined
   notify: "Restart LNet service"
 
+- name: Configure lnet.service override
+  when: lustre_lnet_systemd_override is defined
+  block:
+    - name: Create systemd drop-in directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/lnet.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Copy override.conf
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/lnet.service.d/override.conf
+        content: "{{ lustre_lnet_systemd_override }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify:
+        - "Run daemon-reload for LNet service"
+        - "Restart LNet service"
+
+- name: Cleanup lnet.service override
+  when: not lustre_lnet_systemd_override is defined
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  notify:
+    - "Run daemon-reload for LNet service"
+    - "Restart LNet service"
+  loop:
+    - /etc/systemd/system/lnet.service.d/override.conf
+    - /etc/systemd/system/lnet.service.d
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
Define the content of the override drop-in file with the variable `lustre_lnet_systemd_override`. The role will ensure no drop-in file exists if the variable is not defined. This will allow safe removal of the file.

This might be useful when the lnet.service file provided with the Lustre client does not allow to load the configuration properly.